### PR TITLE
Ineffecient query caused by record_id as string instead of integer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
     t.spec_files = FileList.new('spec/**/*_spec.rb')
   end
 rescue LoadError
-  tast :test do
+  task :test do
     STDERR.puts "You must have rspec >= 1.3.0 to run the tests"
   end
 end

--- a/lib/sunspot/index_queue/entry/active_record_impl.rb
+++ b/lib/sunspot/index_queue/entry/active_record_impl.rb
@@ -105,7 +105,7 @@ module Sunspot
               t.integer :attempts, :null => false, :default => 0
             end
 
-            connection.add_index table_name, [:record_class_name, :record_id], :name => "#{table_name}_record"
+            connection.add_index table_name, [:record_id], :name => "#{table_name}_record_id"
             connection.add_index table_name, [:run_at, :record_class_name, :priority], :name => "#{table_name}_run_at"
           end
         end

--- a/lib/sunspot/index_queue/entry/active_record_impl.rb
+++ b/lib/sunspot/index_queue/entry/active_record_impl.rb
@@ -96,7 +96,7 @@ module Sunspot
           def create_table
             connection.create_table table_name do |t|
               t.string :record_class_name, :null => false
-              t.string :record_id, :null => false
+              t.integer :record_id, :null => false
               t.boolean :is_delete, :null => false, :default => false
               t.datetime :run_at, :null => false
               t.integer :priority, :null => false, :default => 0

--- a/lib/sunspot/index_queue/entry/data_mapper_impl.rb
+++ b/lib/sunspot/index_queue/entry/data_mapper_impl.rb
@@ -14,7 +14,7 @@ module Sunspot
         storage_names[:default] = "sunspot_index_queue_entries"
         property :id, Serial
         property :run_at, Time, :index => :run_at
-        property :record_class_name, String, :index => [:record, :run_at]
+        property :record_class_name, String, :index => [:run_at]
         property :record_id, Integer, :index => [:record]
         property :priority, Integer, :default => 0, :index => :run_at
         property :is_delete, Boolean

--- a/lib/sunspot/index_queue/entry/data_mapper_impl.rb
+++ b/lib/sunspot/index_queue/entry/data_mapper_impl.rb
@@ -15,7 +15,7 @@ module Sunspot
         property :id, Serial
         property :run_at, Time, :index => :run_at
         property :record_class_name, String, :index => [:record, :run_at]
-        property :record_id, String, :index => [:record]
+        property :record_id, Integer, :index => [:record]
         property :priority, Integer, :default => 0, :index => :run_at
         property :is_delete, Boolean
         property :lock, Integer

--- a/spec/entry_impl_examples.rb
+++ b/spec/entry_impl_examples.rb
@@ -11,13 +11,13 @@ shared_examples_for "Entry implementation" do
   context "class methods" do
     before :each do
       test_class = "Sunspot::IndexQueue::Test::Searchable"
-      @entry_1 = factory.create('record_class_name' => test_class, 'record_id' => '1', 'is_delete' => false, 'priority' => 0, 'run_at' => Time.now.utc)
-      @entry_2 = factory.create('record_class_name' => test_class, 'record_id' => '2', 'is_delete' => false, 'priority' => 10, 'run_at' => Time.now.utc, 'error' => "boom!", 'attempts' => 1)
-      @entry_3 = factory.create('record_class_name' => "Object", 'record_id' => '3', 'is_delete' => false, 'priority' => 5, 'run_at' => Time.now.utc, 'error' => "boom!", 'attempts' => 1)
-      @entry_4 = factory.create('record_class_name' => test_class, 'record_id' => '4', 'is_delete' => true, 'priority' => 0, 'run_at' => Time.now.utc + 60)
-      @entry_5 = factory.create('record_class_name' => test_class, 'record_id' => '5', 'is_delete' => false, 'priority' => -10, 'run_at' => Time.now.utc - 60)
-      @entry_6 = factory.create('record_class_name' => test_class, 'record_id' => '6', 'is_delete' => false, 'priority' => 0, 'run_at' => Time.now.utc - 3600)
-      @entry_7 = factory.create('record_class_name' => test_class, 'record_id' => '7', 'is_delete' => true, 'priority' => 10, 'run_at' => Time.now.utc - 60)
+      @entry_1 = factory.create('record_class_name' => test_class, 'record_id' => 1, 'is_delete' => false, 'priority' => 0, 'run_at' => Time.now.utc)
+      @entry_2 = factory.create('record_class_name' => test_class, 'record_id' => 2, 'is_delete' => false, 'priority' => 10, 'run_at' => Time.now.utc, 'error' => "boom!", 'attempts' => 1)
+      @entry_3 = factory.create('record_class_name' => "Object", 'record_id' => 3, 'is_delete' => false, 'priority' => 5, 'run_at' => Time.now.utc, 'error' => "boom!", 'attempts' => 1)
+      @entry_4 = factory.create('record_class_name' => test_class, 'record_id' => 4, 'is_delete' => true, 'priority' => 0, 'run_at' => Time.now.utc + 60)
+      @entry_5 = factory.create('record_class_name' => test_class, 'record_id' => 5, 'is_delete' => false, 'priority' => -10, 'run_at' => Time.now.utc - 60)
+      @entry_6 = factory.create('record_class_name' => test_class, 'record_id' => 6, 'is_delete' => false, 'priority' => 0, 'run_at' => Time.now.utc - 3600)
+      @entry_7 = factory.create('record_class_name' => test_class, 'record_id' => 7, 'is_delete' => true, 'priority' => 10, 'run_at' => Time.now.utc - 60)
     end
     
     context "without class_names filter" do
@@ -107,10 +107,10 @@ shared_examples_for "Entry implementation" do
     
     context "add and remove" do
       it "should add an entry" do
-        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, "10", false, 100)
+        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, 10, false, 100)
         entry = Sunspot::IndexQueue::Entry.implementation.next_batch!(Sunspot::IndexQueue.new).detect{|e| e.priority == 100}
         entry.record_class_name.should == "Sunspot::IndexQueue::Test::Searchable"
-        entry.record_id.should == "10"
+        entry.record_id.should == 10
         entry.is_delete?.should == false
         entry.priority.should == 100
       end
@@ -123,14 +123,14 @@ shared_examples_for "Entry implementation" do
       end
       
       it "should not add multiple entries unless a row is being processed" do
-        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, "10", false, 80)
+        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, 10, false, 80)
         Sunspot::IndexQueue::Entry.implementation.next_batch!(Sunspot::IndexQueue.new)
-        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, "10", false, 100)
-        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, "10", false, 110)
-        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, "10", true, 90)
+        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, 10, false, 100)
+        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, 10, false, 110)
+        Sunspot::IndexQueue::Entry.implementation.add(Sunspot::IndexQueue::Test::Searchable, 10, true, 90)
         Sunspot::IndexQueue::Entry.implementation.reset!(Sunspot::IndexQueue.new)
         entries = Sunspot::IndexQueue::Entry.implementation.next_batch!(Sunspot::IndexQueue.new)
-        entries.detect{|e| e.priority == 80}.record_id.should == "10"
+        entries.detect{|e| e.priority == 80}.record_id.should == 10
         entries.detect{|e| e.priority == 100}.should == nil
         entries.detect{|e| e.priority == 90}.should == nil
         entry = entries.detect{|e| e.priority == 110}
@@ -147,8 +147,8 @@ shared_examples_for "Entry implementation" do
     end
   
     it "should get the record_id" do
-      entry = Sunspot::IndexQueue::Entry.implementation.new('record_id' => "1")
-      entry.record_id.should == "1"
+      entry = Sunspot::IndexQueue::Entry.implementation.new('record_id' => 1)
+      entry.record_id.should == 1
     end
   
     it "should determine if the entry is an delete" do

--- a/spec/entry_spec.rb
+++ b/spec/entry_spec.rb
@@ -117,26 +117,26 @@ describe Sunspot::IndexQueue::Entry do
       entry_3 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable::Subclass", :record_id => 3)
       Sunspot::IndexQueue::Entry.load_all_records([entry_1, entry_2, entry_3])
       record_1 = entry_1.instance_variable_get(:@record)
-      record_1.should == Sunspot::IndexQueue::Test::Searchable.new("1")
+      record_1.should == Sunspot::IndexQueue::Test::Searchable.new(1)
       entry_1.record.object_id.should == record_1.object_id
       record_2 = entry_2.instance_variable_get(:@record)
-      record_2.should == Sunspot::IndexQueue::Test::Searchable.new("2")
+      record_2.should == Sunspot::IndexQueue::Test::Searchable.new(2)
       entry_2.record.object_id.should == record_2.object_id
       record_3 = entry_3.instance_variable_get(:@record)
-      record_3.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new("3")
+      record_3.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(3)
       entry_3.record.object_id.should == record_3.object_id
     end
   end
   
   context "instance methods" do
     it "should get a record for the entry using the Sunspot DataAccessor" do
-      entry = Sunspot::IndexQueue::Entry::MockImpl.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => "1")
+      entry = Sunspot::IndexQueue::Entry::MockImpl.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 1)
       entry.record.class.should == Sunspot::IndexQueue::Test::Searchable
-      entry.record.id.should == "1"
+      entry.record.id.should == 1
     end
     
     it "should set if an entry has been processed" do
-      entry = Sunspot::IndexQueue::Entry::MockImpl.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => "1")
+      entry = Sunspot::IndexQueue::Entry::MockImpl.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 1)
       entry.processed?.should == false
       entry.processed = true
       entry.processed?.should == true

--- a/spec/index_queue_spec.rb
+++ b/spec/index_queue_spec.rb
@@ -92,14 +92,14 @@ describe Sunspot::IndexQueue do
     let(:record_1) { Sunspot::IndexQueue::Test::Searchable.new(1) }
     let(:record_2) { Sunspot::IndexQueue::Test::Searchable.new(2) }
     let(:record_3) { Sunspot::IndexQueue::Test::Searchable.new(3) }
-    
+
     it "should process all entries in the queue in batch of batch_size" do
       Sunspot::IndexQueue::Entry.should_receive(:next_batch!).with(queue).and_return([entry_1, entry_2], [entry_3], [])
       Sunspot::IndexQueue::Entry::MockImpl.should_receive(:ready_count).with(queue).and_return(0)
       queue.session.should_receive(:batch).twice.and_yield
-      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", "1")
-      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", "2")
-      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", "3")
+      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", 1)
+      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", 2)
+      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", 3)
       queue.session.should_receive(:commit).twice
       Sunspot::IndexQueue::Entry::MockImpl.should_receive(:delete_entries).with([entry_1, entry_2])
       Sunspot::IndexQueue::Entry::MockImpl.should_receive(:delete_entries).with([entry_3])
@@ -110,9 +110,9 @@ describe Sunspot::IndexQueue do
       Sunspot::IndexQueue::Entry.should_receive(:next_batch!).with(queue).and_return([entry_1, entry_2], [entry_3], [])
       Sunspot::IndexQueue::Entry::MockImpl.should_receive(:ready_count).with(queue).and_return(0)
       queue.session.should_receive(:batch).twice.and_yield
-      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", "1")
-      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", "2")
-      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", "3")
+      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", 1)
+      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", 2)
+      queue.session.should_receive(:remove_by_id).with("Sunspot::IndexQueue::Test::Searchable", 3)
       queue.session.should_receive(:commit).twice
       Sunspot::IndexQueue::Entry::MockImpl.should_receive(:delete_entries).with([entry_1, entry_2])
       Sunspot::IndexQueue::Entry::MockImpl.should_receive(:delete_entries).with([entry_3])

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -50,9 +50,9 @@ describe "Sunspot::IndexQueue integration tests" do
   
   it "should actually work" do
     Sunspot::IndexQueue::Test::Searchable.mock_db do
-      record_1 = Sunspot::IndexQueue::Test::Searchable.new("1", "one")
-      record_2 = Sunspot::IndexQueue::Test::Searchable.new("2", "two")
-      record_3 = Sunspot::IndexQueue::Test::Searchable::Subclass.new("3", "three")
+      record_1 = Sunspot::IndexQueue::Test::Searchable.new(1, "one")
+      record_2 = Sunspot::IndexQueue::Test::Searchable.new(2, "two")
+      record_3 = Sunspot::IndexQueue::Test::Searchable::Subclass.new(3, "three")
       Sunspot::IndexQueue::Test::Searchable.save(record_1, record_2, record_3)
     
       # Enqueue records

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,7 @@ module Sunspot
         class Subclass < Searchable
         end
       end
-      
+
       Sunspot::Adapters::InstanceAdapter.register(Searchable::InstanceAdapter, Searchable)
       Sunspot::Adapters::DataAccessor.register(Searchable::DataAccessor, Searchable)
       Sunspot.setup(Searchable) do
@@ -72,10 +72,10 @@ module Sunspot
         def initialize (options = {})
           if options[:record]
             @record_class_name = options[:record].class.name
-            @record_id = options[:record].id.to_s
+            @record_id = options[:record].id
           else
             @record_class_name = options[:record_class_name]
-            @record_id = options[:record_id].to_s
+            @record_id = options[:record_id]
           end
           @is_delete = !!options[:delete]
         end


### PR DESCRIPTION
When we went to full production volume with this gem, the ActiveRecordImpl hammered the mysql database in an unexpected way.  EXPLAIN demonstrated that there were _way_ too many candidate rows, and the index size of 257 that couldn't possibly include two 255-byte fields.

When we altered the database to make record_id an integer instead of a string, it changed the number of candidate rows to exactly 1.  

... but that cost us 261 bytes of index per row.  Changing the index to simply focus on the record_id, we are able to narrow the number of candidates to at _most_ the number of AR classes who have a pending queue_entry, but in more common cases still just one candidate, with (drumroll) 4 bytes of index key per row.
