### PR TITLE
Fixed active record indexing of multiple classes.

### DIFF
--- a/lib/sunspot/index_queue/entry/active_record_impl.rb
+++ b/lib/sunspot/index_queue/entry/active_record_impl.rb
@@ -70,6 +70,7 @@ module Sunspot
           def next_batch!(queue)
             conditions = ["#{connection.quote_column_name('run_at')} <= ?", Time.now.utc]
             classes = group(:record_class_name).map{|g| g.record_class_name}.compact
+            return [] unless classes.length > 0
             classes = classes.map{|u| u if queue.class_names.include?(u)}.compact unless queue.class_names.empty?
             if classes
               conditions.first << " AND #{connection.quote_column_name('record_class_name')} IN (?)"

--- a/lib/sunspot/index_queue/entry/active_record_impl.rb
+++ b/lib/sunspot/index_queue/entry/active_record_impl.rb
@@ -69,9 +69,11 @@ module Sunspot
           # Implementation of the next_batch! method.
           def next_batch!(queue)
             conditions = ["#{connection.quote_column_name('run_at')} <= ?", Time.now.utc]
-            unless queue.class_names.empty?
+            classes = group(:record_class_name).map{|g| g.record_class_name}.compact
+            classes = classes.map{|u| u if queue.class_names.include?(u)}.compact unless queue.class_names.empty?
+            if classes
               conditions.first << " AND #{connection.quote_column_name('record_class_name')} IN (?)"
-              conditions << queue.class_names
+              conditions << classes.first
             end
             batch_entries = all(:select => "id", :conditions => conditions, :limit => queue.batch_size, :order => 'priority DESC, run_at')
             queue_entry_ids = batch_entries.collect{|entry| entry.id}


### PR DESCRIPTION
I fixed a bug in the active record implementation of next_batch function, that was highlighted in issue #7. The problem is that any type of Class name would be given to the batcher and then some of the records would not be indexed. From my tests it appeared to be records that weren't of the same class as the first object passed to be batcher.

This is more likely an issue with the sunspot code with their batch indexing but because their code never uses this type of multi class indexing at once (all their reindex and index code does 1 class at a time) they would never experience it. I am going to look closer at that, but for now this is a good work around. It causes 1 extra sql query per batch as a consequence of completely it in this manner.

I have never used datamapper or mongodb so not sure if they are also affected or how to fix it properly.
