### PR TITLE
Fix for Entry#load_all_records

### DIFF
--- a/spec/entry_spec.rb
+++ b/spec/entry_spec.rb
@@ -126,6 +126,27 @@ describe Sunspot::IndexQueue::Entry do
       record_3.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(3)
       entry_3.record.object_id.should == record_3.object_id
     end
+    
+    it "should load all records for an array of entries at once even if ids clash between record class names" do
+      entry_1 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 1)
+      entry_2 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 2)
+      entry_3 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable::Subclass", :record_id => 1)
+      entry_4 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable::Subclass", :record_id => 2)
+      Sunspot::IndexQueue::Entry.load_all_records([entry_1, entry_2, entry_3, entry_4])
+      record_1 = entry_1.instance_variable_get(:@record)
+      record_1.should == Sunspot::IndexQueue::Test::Searchable.new(1)
+      entry_1.record.object_id.should == record_1.object_id
+      record_2 = entry_2.instance_variable_get(:@record)
+      record_2.should == Sunspot::IndexQueue::Test::Searchable.new(2)
+      entry_2.record.object_id.should == record_2.object_id
+      record_3 = entry_3.instance_variable_get(:@record)
+      record_3.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(1)
+      entry_3.record.object_id.should == record_3.object_id
+      record_4 = entry_4.instance_variable_get(:@record)
+      record_4.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(2)
+      entry_4.record.object_id.should == record_4.object_id
+    end
+    
   end
   
   context "instance methods" do

--- a/spec/entry_spec.rb
+++ b/spec/entry_spec.rb
@@ -111,40 +111,42 @@ describe Sunspot::IndexQueue::Entry do
       lambda{ Sunspot::IndexQueue::Entry.enqueue(queue, Object, 1, false) }.should raise_error(ArgumentError)
     end
     
-    it "should load all records for an array of entries at once" do
-      entry_1 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 1)
-      entry_2 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 2)
-      entry_3 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable::Subclass", :record_id => 3)
-      Sunspot::IndexQueue::Entry.load_all_records([entry_1, entry_2, entry_3])
-      record_1 = entry_1.instance_variable_get(:@record)
-      record_1.should == Sunspot::IndexQueue::Test::Searchable.new(1)
-      entry_1.record.object_id.should == record_1.object_id
-      record_2 = entry_2.instance_variable_get(:@record)
-      record_2.should == Sunspot::IndexQueue::Test::Searchable.new(2)
-      entry_2.record.object_id.should == record_2.object_id
-      record_3 = entry_3.instance_variable_get(:@record)
-      record_3.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(3)
-      entry_3.record.object_id.should == record_3.object_id
-    end
+    context "load all records" do
+      it "should load all records for an array of entries at once" do
+        entry_1 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 1)
+        entry_2 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 2)
+        entry_3 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable::Subclass", :record_id => 3)
+        Sunspot::IndexQueue::Entry.load_all_records([entry_1, entry_2, entry_3])
+        record_1 = entry_1.instance_variable_get(:@record)
+        record_1.should == Sunspot::IndexQueue::Test::Searchable.new(1)
+        entry_1.record.object_id.should == record_1.object_id
+        record_2 = entry_2.instance_variable_get(:@record)
+        record_2.should == Sunspot::IndexQueue::Test::Searchable.new(2)
+        entry_2.record.object_id.should == record_2.object_id
+        record_3 = entry_3.instance_variable_get(:@record)
+        record_3.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(3)
+        entry_3.record.object_id.should == record_3.object_id
+      end
     
-    it "should load all records for an array of entries at once even if ids clash between record class names" do
-      entry_1 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 1)
-      entry_2 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 2)
-      entry_3 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable::Subclass", :record_id => 1)
-      entry_4 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable::Subclass", :record_id => 2)
-      Sunspot::IndexQueue::Entry.load_all_records([entry_1, entry_2, entry_3, entry_4])
-      record_1 = entry_1.instance_variable_get(:@record)
-      record_1.should == Sunspot::IndexQueue::Test::Searchable.new(1)
-      entry_1.record.object_id.should == record_1.object_id
-      record_2 = entry_2.instance_variable_get(:@record)
-      record_2.should == Sunspot::IndexQueue::Test::Searchable.new(2)
-      entry_2.record.object_id.should == record_2.object_id
-      record_3 = entry_3.instance_variable_get(:@record)
-      record_3.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(1)
-      entry_3.record.object_id.should == record_3.object_id
-      record_4 = entry_4.instance_variable_get(:@record)
-      record_4.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(2)
-      entry_4.record.object_id.should == record_4.object_id
+      it "should load all records for an array of entries at once even if ids clash between record class names" do
+        entry_1 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 1)
+        entry_2 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable", :record_id => 2)
+        entry_3 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable::Subclass", :record_id => 1)
+        entry_4 = Sunspot::IndexQueue::Entry.implementation.new(:record_class_name => "Sunspot::IndexQueue::Test::Searchable::Subclass", :record_id => 2)
+        Sunspot::IndexQueue::Entry.load_all_records([entry_1, entry_2, entry_3, entry_4])
+        record_1 = entry_1.instance_variable_get(:@record)
+        record_1.should == Sunspot::IndexQueue::Test::Searchable.new(1)
+        entry_1.record.object_id.should == record_1.object_id
+        record_2 = entry_2.instance_variable_get(:@record)
+        record_2.should == Sunspot::IndexQueue::Test::Searchable.new(2)
+        entry_2.record.object_id.should == record_2.object_id
+        record_3 = entry_3.instance_variable_get(:@record)
+        record_3.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(1)
+        entry_3.record.object_id.should == record_3.object_id
+        record_4 = entry_4.instance_variable_get(:@record)
+        record_4.should == Sunspot::IndexQueue::Test::Searchable::Subclass.new(2)
+        entry_4.record.object_id.should == record_4.object_id
+      end
     end
     
   end


### PR DESCRIPTION
The current implementation of Entry#load_all_records will load the incorrect records into entries if the IDs and record class names clash. Some examples:
entries = [ ModelA 1, ModelB 1]

The code will not correctly map between the entries for ModelA v B because it uses only ID.

Another example:
entries [ModelA 1, ModelB 2]

But there exists in the database a ModelB 1 as well.  In this case since all IDs are put in the load query each time entry for ModelA 1 may get loaded with ModelB1.

This code changes the hash key to be the class name + id, and also creates a hash of ID arrays per class type for the load call.

Scott Diedrick
