### PR TITLE
Convert ids from BSON::ObjectId to String when using Mongoid

### DIFF
--- a/lib/sunspot/index_queue/entry.rb
+++ b/lib/sunspot/index_queue/entry.rb
@@ -109,6 +109,7 @@ module Sunspot
             if klass.respond_to?(:sunspot_options) && klass.sunspot_options && klass.sunspot_options[:include] && adapter.respond_to?(:include=)
               adapter.include = klass.sunspot_options[:include]
             end
+            ids.map! {|id| id.to_s } if adapter.class.name == "Sunspot::Mongoid::DataAccessor"
             adapter.load_all(ids).each do |record|
               entry = map[Sunspot::Adapters::InstanceAdapter.adapt(record).id.to_s]
               entry.instance_variable_set(:@record, record) if entry


### PR DESCRIPTION
When retrieving the entries mongoid seems to be converting the
record_id from a String to a BSON::ObjectId, and so when calling
adapter.load_all(ids) and the ids are not strings it returns a illegal
ObjectId format error.
