### PR TITLE
Eliminate ActiveRecord deprecation warning for `set_table_name`

### DIFF
--- a/lib/sunspot/index_queue/entry/active_record_impl.rb
+++ b/lib/sunspot/index_queue/entry/active_record_impl.rb
@@ -21,7 +21,7 @@ module Sunspot
       class ActiveRecordImpl < ActiveRecord::Base
         include Entry
         
-        set_table_name :sunspot_index_queue_entries
+        self.table_name = "sunspot_index_queue_entries"
 
         class << self
           # Implementation of the total_count method.


### PR DESCRIPTION
ActiveRecord is deprecating `set_table_name`. This Pull Request updates to the latest convention which is `self.table_name =`.
