### PR TITLE
Fix AR-backed queue insert in Rails 3.2 when mass assignment security is...

### DIFF
--- a/lib/sunspot/index_queue/entry/active_record_impl.rb
+++ b/lib/sunspot/index_queue/entry/active_record_impl.rb
@@ -20,9 +20,16 @@ module Sunspot
       # as the primary key, you can add additional statements to the migration to do so.
       class ActiveRecordImpl < ActiveRecord::Base
         include Entry
-        
-        attr_accessible :record_id, :record_class_name, :lock, :priority
-        
+
+        attr_accessible :attempts,
+                        :error,
+                        :is_delete,
+                        :lock,
+                        :priority,
+                        :record_class_name,
+                        :record_id,
+                        :run_at
+
         self.table_name = "sunspot_index_queue_entries"
 
         class << self

--- a/lib/sunspot/index_queue/entry/active_record_impl.rb
+++ b/lib/sunspot/index_queue/entry/active_record_impl.rb
@@ -21,6 +21,8 @@ module Sunspot
       class ActiveRecordImpl < ActiveRecord::Base
         include Entry
         
+        attr_accessible :record_id, :record_class_name, :lock, :priority
+        
         self.table_name = "sunspot_index_queue_entries"
 
         class << self


### PR DESCRIPTION
... enabled

Fixes the following exception being thrown during record creation when
config.active_record.whitelist_attributes = true

ActiveModel::MassAssignmentSecurity::Error
(Can't mass-assign protected attributes: record_id, record_class_name,
lock, priority)
